### PR TITLE
Stone and trade with item are swaped

### DIFF
--- a/PokeRoms.ini
+++ b/PokeRoms.ini
@@ -125,7 +125,7 @@ numberofhms = 8
 evolutiontable = 0x32531C
 evolutionsperpoke = 5
 lengthofoneentry = 8
-evolutionmethods = Breeding Only,Friendship,Friendship (Day),Friendship (Night),Level-Up,Trade,Stone,Trade (Hold Item),ATK > DEF,ATK = DEF,ATK < DEF,PID (Wurmple->Silcoon),PID (Wurmple->Cascoon),Spawn a Second,Create Spawn,Beauty
+evolutionmethods = Breeding Only,Friendship,Friendship (Day),Friendship (Night),Level-Up,Trade,Trade (Hold Item),Stone,ATK > DEF,ATK = DEF,ATK < DEF,PID (Wurmple->Silcoon),PID (Wurmple->Cascoon),Spawn a Second,Create Spawn,Beauty
 evomethodsproperties = None,None,None,None,Level,None,Item,Item,Level,Level,Level,Level,Level,Level,Level,None
 evolutiontablepointers = 0x6D140,0x6D190,0x6D234,0x6D384,0x70030,0x13E558
 offsetstochangetolslr0r60x1 = 0x6D170,0x6D38E,0x6D1DC,0x6D238,0x6D248,0x6D272,0x6D29C,0x6D2CA,0x6D2EA,0x6D30E,0x6D31E
@@ -198,7 +198,7 @@ numberofhms = 8
 evolutiontable = 0x203B68
 evolutionsperpoke = 5
 lengthofoneentry = 8
-evolutionmethods = Breeding Only,Friendship,Friendship (Day),Friendship (Night),Level-Up,Trade,Stone,Trade (Hold Item),ATK > DEF,ATK = DEF,ATK < DEF,PID (Wurmple->Silcoon),PID (Wurmple->Cascoon),Spawn a Second,Create Spawn,Beauty
+evolutionmethods = Breeding Only,Friendship,Friendship (Day),Friendship (Night),Level-Up,Trade,Trade (Hold Item),Stone,ATK > DEF,ATK = DEF,ATK < DEF,PID (Wurmple->Silcoon),PID (Wurmple->Cascoon),Spawn a Second,Create Spawn,Beauty
 evomethodsproperties = None,None,None,None,Level,None,Item,Item,Level,Level,Level,Level,Level,Level,Level,None
 evolutiontablepointers = 0x3F534,0x3F584,0x3F628,0x3F778,0x4189C,0x1123F4
 offsetstochangetolslr0r60x1 = 0x3F564,0x3F782,0x3F5D0,0x3F62C,0x3F63C,0x3F666,0x3F690,0x3F6BE,0x3F6DE,0x3F702,0x3F712
@@ -266,7 +266,7 @@ numberofhms = 8
 evolutiontable = 0x259734
 evolutionsperpoke = 5
 lengthofoneentry = 8
-evolutionmethods = Breeding Only,Friendship,Friendship (Day),Friendship (Night),Level-Up,Trade,Stone,Trade (Hold Item),ATK > DEF,ATK = DEF,ATK < DEF,PID (Wurmple->Silcoon),PID (Wurmple->Cascoon),Spawn a Second,Create Spawn,Beauty
+evolutionmethods = Breeding Only,Friendship,Friendship (Day),Friendship (Night),Level-Up,Trade,Trade (Hold Item),Stone,ATK > DEF,ATK = DEF,ATK < DEF,PID (Wurmple->Silcoon),PID (Wurmple->Cascoon),Spawn a Second,Create Spawn,Beauty
 evomethodsproperties = None,None,None,None,Level,None,Item,Item,Level,Level,Level,Level,Level,Level,Level,None
 evolutiontablepointers = 0x42F6C,0x42fbc,0x43138,0x4599c,0xCE898
 offsetstochangetolslr0r60x1 = 0x42f9c,0x43182,0x43026,0x43008,0x43016,0x43050,0x4307A,0x430A8,0x430C8,0x430EC,0x430FC
@@ -339,7 +339,7 @@ numberofhms = 8
 evolutiontable = 0x203AF8
 evolutionsperpoke = 5
 lengthofoneentry = 8
-evolutionmethods = Breeding Only,Friendship,Friendship (Day),Friendship (Night),Level-Up,Trade,Stone,Trade (Hold Item),ATK > DEF,ATK = DEF,ATK < DEF,PID (Wurmple->Silcoon),PID (Wurmple->Cascoon),Spawn a Second,Create Spawn,Beauty
+evolutionmethods = Breeding Only,Friendship,Friendship (Day),Friendship (Night),Level-Up,Trade,Trade (Hold Item),Stone,ATK > DEF,ATK = DEF,ATK < DEF,PID (Wurmple->Silcoon),PID (Wurmple->Cascoon),Spawn a Second,Create Spawn,Beauty
 evomethodsproperties = None,None,None,None,Level,None,Item,Item,Level,Level,Level,Level,Level,Level,Level,None
 evolutiontablepointers = 0x3f534,0x3f584,0x3f628,0x3f778,0x4189c,0x1123F4
 offsetstochangetolslr0r60x1 = 0x3F564,0x3F782,0x3F5D0,0x3F62C,0x3F63C,0x3F666,0x3F690,0x3F6BE,0x3F6DE,0x3F702,0x3F712


### PR DESCRIPTION
This fixes a bug in evolution methods. Currently, it shows stone as trade with item. This change fixes the problem.

Tested with Emerald.